### PR TITLE
fix(ci): docker workflow 0s 失败——secrets 在 step if 里被禁用

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,12 @@ jobs:
       contents: read
       packages: write
 
+    # Job-level env captures the secret presence so step-level `if:` can use it.
+    # Referencing ${{ secrets.X }} directly inside step-level `if:` is rejected
+    # by Actions and causes a 0s "workflow file issue" failure.
+    env:
+      HAS_DOCKERHUB: ${{ secrets.DOCKER_USERNAME != '' && secrets.DOCKER_PASSWORD != '' }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -20,7 +26,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        if: ${{ secrets.DOCKER_USERNAME != '' }}
+        if: env.HAS_DOCKERHUB == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -45,7 +51,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ secrets.DOCKER_USERNAME != '' }}
+          push: ${{ env.HAS_DOCKERHUB == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Why

PR #9 合并后 \`docker.yml\` 直接 0 秒失败：

> This run likely failed because of a workflow file issue.

原因：原文件用了

\`\`\`yaml
- name: Log in to Docker Hub
  if: \${{ secrets.DOCKER_USERNAME != '' }}
\`\`\`

GitHub Actions 不允许 \`secrets\` context 出现在 step 级 \`if:\` 里。整个 workflow 解析就挂了。

## Fix

在 job 级 \`env:\` 里把 secret 存在性求值成布尔字符串，step 级 \`if:\` 引用这个 env 变量（这是合法写法）：

\`\`\`yaml
env:
  HAS_DOCKERHUB: \${{ secrets.DOCKER_USERNAME != '' && secrets.DOCKER_PASSWORD != '' }}

steps:
  - if: env.HAS_DOCKERHUB == 'true'
    ...
\`\`\`

## Test plan
- [x] yaml 语法本地通过（GitHub Actions 表达式语法没法本地完全验证，但模式是 [docs 推荐写法](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow)）
- [ ] 合并后看实际 CI 跑通、镜像推到 \`orwellz/jmcomic-api\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI：
- 使用从机密中派生的作业级环境变量标志来控制 Docker Hub 登录和镜像推送步骤，避免在步骤级 `if` 条件中不当使用机密信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Guard Docker Hub login and image push steps using a job-level env flag derived from secrets, avoiding invalid use of secrets in step-level if conditions.

</details>