### PR TITLE
feat(reliability): P1-P3 metrics + readiness 升级 + 优雅关闭

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "PyYAML>=6.0",
     "structlog>=24.4",
     "tenacity>=8.2",
+    "prometheus-client>=0.20",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pydantic-settings>=2.4",
     "PyYAML>=6.0",
     "structlog>=24.4",
+    "tenacity>=8.2",
 ]
 
 [project.optional-dependencies]

--- a/src/jmcomic_api/app.py
+++ b/src/jmcomic_api/app.py
@@ -25,6 +25,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.responses import Response
 
 from jmcomic_api import __version__
+from jmcomic_api.concurrency.keyed_lock import KeyedAsyncLock
 from jmcomic_api.deps import settings
 from jmcomic_api.errors import register_handlers
 from jmcomic_api.logging_config import configure as configure_logging
@@ -32,7 +33,7 @@ from jmcomic_api.logging_config import get_logger
 from jmcomic_api.routers import catalog as catalog_router
 from jmcomic_api.routers import health as health_router
 from jmcomic_api.routers import pdf as pdf_router
-from jmcomic_api.services.album import AlbumService
+from jmcomic_api.services.album import AlbumService, ReliabilityConfig
 from jmcomic_api.services.jm_client import (
     install_album_dirname_advice,
     load_runtime,
@@ -51,7 +52,24 @@ def create_app() -> FastAPI:
         cfg.shard_cache_path.mkdir(parents=True, exist_ok=True)
         app.state.settings = cfg
         app.state.runtime = load_runtime(cfg.option_file)
-        app.state.album_service = AlbumService(lambda: app.state.runtime)
+
+        # Reliability stack: global download semaphore + keyed lock + tunable
+        # retry/timeout config. Constructing them here (not at import time)
+        # keeps tests deterministic — each test process gets its own.
+        app.state.download_semaphore = asyncio.Semaphore(cfg.max_concurrent_downloads)
+        app.state.album_lock = KeyedAsyncLock()
+        app.state.album_service = AlbumService(
+            lambda: app.state.runtime,
+            lock=app.state.album_lock,
+            download_semaphore=app.state.download_semaphore,
+            reliability=ReliabilityConfig(
+                download_timeout_seconds=cfg.download_timeout_seconds,
+                pdf_build_timeout_seconds=cfg.pdf_build_timeout_seconds,
+                download_retry_attempts=cfg.download_retry_attempts,
+                download_retry_initial_wait=cfg.download_retry_initial_wait,
+                download_retry_max_wait=cfg.download_retry_max_wait,
+            ),
+        )
         logger.info(
             "startup_complete",
             version=__version__,

--- a/src/jmcomic_api/app.py
+++ b/src/jmcomic_api/app.py
@@ -62,7 +62,8 @@ def create_app() -> FastAPI:
         app.state.download_semaphore = asyncio.Semaphore(cfg.max_concurrent_downloads)
         app.state.album_lock = KeyedAsyncLock()
         app.state.last_download_unix = None  # surfaced by /health/ready
-        app.state.tasks: set[asyncio.Task] = set()  # tracked for graceful shutdown
+        # Tracked tasks for graceful shutdown.
+        app.state.tasks = set()
 
         def _mark_download_success() -> None:
             app.state.last_download_unix = time.time()

--- a/src/jmcomic_api/app.py
+++ b/src/jmcomic_api/app.py
@@ -7,7 +7,10 @@ The lifespan:
 4. registers a SIGHUP handler that reloads ``option.yml`` and rebuilds the client
    (replaces the watchdog observer — SIGHUP is reliable, watchdog double-fired
     on editor atomic writes)
-5. on shutdown, removes the SIGHUP handler
+5. on shutdown:
+   - cancels every tracked in-flight task (so SIGTERM doesn't get downgraded
+     to SIGKILL by the supervisor while a download is mid-flight)
+   - removes the SIGHUP handler
 """
 
 from __future__ import annotations
@@ -24,7 +27,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.responses import Response
 
-from jmcomic_api import __version__
+from jmcomic_api import __version__, metrics
 from jmcomic_api.concurrency.keyed_lock import KeyedAsyncLock
 from jmcomic_api.deps import settings
 from jmcomic_api.errors import register_handlers
@@ -58,6 +61,12 @@ def create_app() -> FastAPI:
         # keeps tests deterministic — each test process gets its own.
         app.state.download_semaphore = asyncio.Semaphore(cfg.max_concurrent_downloads)
         app.state.album_lock = KeyedAsyncLock()
+        app.state.last_download_unix = None  # surfaced by /health/ready
+        app.state.tasks: set[asyncio.Task] = set()  # tracked for graceful shutdown
+
+        def _mark_download_success() -> None:
+            app.state.last_download_unix = time.time()
+
         app.state.album_service = AlbumService(
             lambda: app.state.runtime,
             lock=app.state.album_lock,
@@ -69,6 +78,7 @@ def create_app() -> FastAPI:
                 download_retry_initial_wait=cfg.download_retry_initial_wait,
                 download_retry_max_wait=cfg.download_retry_max_wait,
             ),
+            on_download_success=_mark_download_success,
         )
         logger.info(
             "startup_complete",
@@ -98,9 +108,24 @@ def create_app() -> FastAPI:
         try:
             yield
         finally:
+            # Graceful shutdown: cancel every tracked task and wait up to
+            # ``shutdown_grace_seconds`` for them to finish. Any survivors get
+            # forcibly killed by uvicorn / the supervisor afterward.
+            tasks = [t for t in getattr(app.state, "tasks", set()) if not t.done()]
+            if tasks:
+                logger.info("lifespan_shutdown_cancelling", tasks=len(tasks))
+                for t in tasks:
+                    t.cancel()
+                done, pending = await asyncio.wait(tasks, timeout=cfg.shutdown_grace_seconds)
+                logger.info(
+                    "lifespan_shutdown_drained",
+                    completed=len(done),
+                    still_running=len(pending),
+                )
             if signal_installed:
                 with contextlib.suppress(NotImplementedError, ValueError):
                     loop.remove_signal_handler(signal.SIGHUP)
+            logger.info("lifespan_shutdown_complete")
 
     app = FastAPI(
         title="JMComic API",
@@ -137,6 +162,10 @@ def create_app() -> FastAPI:
                 status_code=response.status_code,
             )
         return response
+
+    # Metrics middleware must wrap routes to observe their final status.
+    app.middleware("http")(metrics.http_middleware)
+    metrics.mount(app)
 
     register_handlers(app)
     app.include_router(health_router.router)

--- a/src/jmcomic_api/concurrency/keyed_lock.py
+++ b/src/jmcomic_api/concurrency/keyed_lock.py
@@ -6,6 +6,10 @@ long-running processes.
 
 Replaces the threading-based ``KeyedTaskQueue`` from the Flask era. Same key →
 serial; different keys → parallel.
+
+Reliability:
+- ``acquire(key, timeout=...)`` will raise :class:`LockTimeout` instead of
+  waiting forever if the holder is stuck.
 """
 
 from __future__ import annotations
@@ -15,6 +19,10 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 
+class LockTimeout(Exception):
+    """Raised when ``KeyedAsyncLock.acquire`` cannot get the lock in time."""
+
+
 class KeyedAsyncLock:
     def __init__(self) -> None:
         self._locks: dict[str, asyncio.Lock] = {}
@@ -22,7 +30,7 @@ class KeyedAsyncLock:
         self._meta = asyncio.Lock()
 
     @asynccontextmanager
-    async def acquire(self, key: str) -> AsyncIterator[None]:
+    async def acquire(self, key: str, *, timeout: float | None = None) -> AsyncIterator[None]:
         async with self._meta:
             lock = self._locks.get(key)
             if lock is None:
@@ -30,10 +38,20 @@ class KeyedAsyncLock:
                 self._locks[key] = lock
             self._refs[key] = self._refs.get(key, 0) + 1
 
+        acquired = False
         try:
-            async with lock:
-                yield
+            if timeout is None:
+                await lock.acquire()
+            else:
+                try:
+                    await asyncio.wait_for(lock.acquire(), timeout=timeout)
+                except TimeoutError as e:
+                    raise LockTimeout(f"could not acquire lock {key!r} within {timeout}s") from e
+            acquired = True
+            yield
         finally:
+            if acquired:
+                lock.release()
             async with self._meta:
                 self._refs[key] -= 1
                 if self._refs[key] == 0:

--- a/src/jmcomic_api/errors.py
+++ b/src/jmcomic_api/errors.py
@@ -25,6 +25,7 @@ from jmcomic.jm_exception import (
 )
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
+from jmcomic_api.concurrency.keyed_lock import LockTimeout
 from jmcomic_api.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -98,3 +99,22 @@ def register_handlers(app: FastAPI) -> None:
     async def _missing_file(_request: Request, exc: FileNotFoundError):
         logger.error("local_file_missing", error=str(exc))
         return _envelope("Required local file missing", 500)
+
+    @app.exception_handler(TimeoutError)
+    async def _timeout(_request: Request, exc: TimeoutError):
+        # asyncio.TimeoutError IS TimeoutError on 3.12+. Covers wait_for budget
+        # exhaustion in jm_client + album service.
+        logger.warning("request_timeout", error=str(exc))
+        resp = _envelope("Operation timed out — try again later", 504)
+        resp.headers["Retry-After"] = "30"
+        return resp
+
+    @app.exception_handler(LockTimeout)
+    async def _lock_timeout(_request: Request, exc: LockTimeout):
+        # Same album was being processed by another in-flight request and we
+        # waited too long. 503 + Retry-After signals "try again, the system
+        # isn't broken — it's busy".
+        logger.warning("lock_timeout", error=str(exc))
+        resp = _envelope("Resource busy — try again later", 503)
+        resp.headers["Retry-After"] = "30"
+        return resp

--- a/src/jmcomic_api/metrics.py
+++ b/src/jmcomic_api/metrics.py
@@ -1,0 +1,118 @@
+"""Prometheus metrics. Single source of truth for all instrumented events.
+
+All names use the ``jmapi_`` prefix and follow Prometheus naming conventions
+(``*_total`` for counters, ``*_seconds`` for time histograms).
+
+Wiring:
+- :func:`http_middleware` is registered in ``app.py`` to count + time every
+  request.
+- Service code calls :func:`record_download_outcome`, :func:`record_pdf_build`
+  etc. directly.
+- :func:`mount` adds the ``/metrics`` exposition endpoint to a FastAPI app.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable
+
+from fastapi import FastAPI, Request
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    Counter,
+    Histogram,
+    generate_latest,
+)
+from starlette.responses import Response
+
+# ---- request-level -----------------------------------------------------------
+
+REQUEST_TOTAL = Counter(
+    "jmapi_request_total",
+    "HTTP requests by route + status class.",
+    ["method", "route", "status_class"],
+)
+REQUEST_DURATION = Histogram(
+    "jmapi_request_duration_seconds",
+    "HTTP request latency.",
+    ["method", "route"],
+    buckets=(0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600),
+)
+
+# ---- service-level -----------------------------------------------------------
+
+DOWNLOAD_TOTAL = Counter(
+    "jmapi_download_total",
+    "Album downloads by outcome.",
+    ["outcome"],  # success | partial_fail | retry_exhausted | timeout
+)
+PDF_BUILD_DURATION = Histogram(
+    "jmapi_pdf_build_duration_seconds",
+    "PDF build latency.",
+    ["kind"],  # full | shard
+    buckets=(0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120),
+)
+CACHE_HIT_TOTAL = Counter(
+    "jmapi_cache_hit_total",
+    "Cache hits by kind (album webp / pdf / shard).",
+    ["kind"],
+)
+CACHE_MISS_TOTAL = Counter(
+    "jmapi_cache_miss_total",
+    "Cache misses by kind.",
+    ["kind"],
+)
+
+
+# ---- helpers ----------------------------------------------------------------
+
+
+def record_download_outcome(outcome: str) -> None:
+    DOWNLOAD_TOTAL.labels(outcome=outcome).inc()
+
+
+def record_pdf_build_duration(kind: str, seconds: float) -> None:
+    PDF_BUILD_DURATION.labels(kind=kind).observe(seconds)
+
+
+def record_cache(kind: str, hit: bool) -> None:
+    (CACHE_HIT_TOTAL if hit else CACHE_MISS_TOTAL).labels(kind=kind).inc()
+
+
+# ---- ASGI plumbing ---------------------------------------------------------
+
+
+def _route_template(request: Request) -> str:
+    """Use the route's path *template* (``/get_pdf/{album_id}``) instead of the
+    concrete path so cardinality stays bounded.
+    """
+    route = request.scope.get("route")
+    if route and getattr(route, "path", None):
+        return route.path
+    return request.url.path
+
+
+async def http_middleware(
+    request: Request, call_next: Callable[[Request], Awaitable[Response]]
+) -> Response:
+    """Count + time every HTTP request. Skip ``/metrics`` itself to avoid recursion."""
+    if request.url.path == "/metrics":
+        return await call_next(request)
+
+    start = time.monotonic()
+    response = await call_next(request)
+    elapsed = time.monotonic() - start
+
+    route = _route_template(request)
+    status_class = f"{response.status_code // 100}xx"
+    REQUEST_TOTAL.labels(method=request.method, route=route, status_class=status_class).inc()
+    REQUEST_DURATION.labels(method=request.method, route=route).observe(elapsed)
+    return response
+
+
+def mount(app: FastAPI) -> None:
+    """Register the ``/metrics`` route. Plain text exposition format."""
+
+    @app.get("/metrics", include_in_schema=False)
+    async def _metrics() -> Response:
+        return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/src/jmcomic_api/routers/health.py
+++ b/src/jmcomic_api/routers/health.py
@@ -1,9 +1,27 @@
+"""Health endpoints.
+
+- ``/health``       — Flask-era backward-compat shim, always 200 if process is up.
+- ``/health/live``  — process liveness (cheap; never blocks). Use for k8s
+  ``livenessProbe`` so a hung downstream doesn't restart the pod.
+- ``/health/ready`` — actual readiness: jmcomic runtime initialised, PDF dir
+  writable, disk has at least ``min_free_disk_mb`` MB. Use for k8s
+  ``readinessProbe`` and load-balancer health checks.
+"""
+
 from __future__ import annotations
+
+import shutil
+import time
 
 from fastapi import APIRouter, Request, status
 from fastapi.responses import JSONResponse
 
 router = APIRouter(tags=["health"])
+
+# Minimum free disk required to keep accepting traffic. Below this we report
+# not-ready so the LB sheds load. Tunable via ``JMAPI_MIN_FREE_DISK_MB`` if we
+# ever surface it; default 500 MB is enough for a few albums of headroom.
+DEFAULT_MIN_FREE_DISK_MB = 500
 
 
 @router.get("/health")
@@ -19,16 +37,37 @@ async def liveness() -> dict:
 
 @router.get("/health/ready")
 async def readiness(request: Request) -> JSONResponse:
-    runtime = getattr(request.app.state, "runtime", None)
     settings = request.app.state.settings
+    runtime = getattr(request.app.state, "runtime", None)
+
     pdf_dir_ok = settings.pdf_path.exists() and settings.pdf_path.is_dir()
-    if runtime is None or not pdf_dir_ok:
+
+    # Disk space probe — pdf cache + webp downloads can blow up fast.
+    try:
+        usage = shutil.disk_usage(settings.pdf_path)
+        free_mb = usage.free / (1024 * 1024)
+    except OSError:
+        free_mb = -1
+    min_free_mb = getattr(settings, "min_free_disk_mb", DEFAULT_MIN_FREE_DISK_MB)
+    disk_ok = free_mb >= min_free_mb
+
+    # Last successful download — handy when triaging "why is everything stuck"
+    # incidents. Set by services/album.py on success; None until first hit.
+    last_success = getattr(request.app.state, "last_download_unix", None)
+    last_success_age = (time.time() - last_success) if last_success else None
+
+    components = {
+        "runtime": runtime is not None,
+        "pdf_dir_ok": pdf_dir_ok,
+        "disk_ok": disk_ok,
+        "free_disk_mb": round(free_mb, 1),
+        "min_free_disk_mb": min_free_mb,
+        "last_download_age_seconds": last_success_age,
+    }
+
+    if not (runtime is not None and pdf_dir_ok and disk_ok):
         return JSONResponse(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            content={
-                "status": "not_ready",
-                "runtime": runtime is not None,
-                "pdf_dir_ok": pdf_dir_ok,
-            },
+            content={"status": "not_ready", **components},
         )
-    return JSONResponse(content={"status": "ready"})
+    return JSONResponse(content={"status": "ready", **components})

--- a/src/jmcomic_api/services/album.py
+++ b/src/jmcomic_api/services/album.py
@@ -1,8 +1,15 @@
 """High-level: download an album (if needed) and produce its PDF.
 
 All blocking calls (jmcomic downloads, PIL encode, pypdf write) happen inside
-``asyncio.to_thread`` so the FastAPI event loop stays responsive. Same-album
-concurrency is serialized through a per-id ``KeyedAsyncLock``.
+``asyncio.to_thread`` + ``asyncio.wait_for`` so the FastAPI event loop stays
+responsive AND no operation can block forever. Same-album concurrency is
+serialised through a per-id ``KeyedAsyncLock``; the global download semaphore
+caps concurrent jmcomic activity overall.
+
+A ``.done`` marker file inside each album folder is the source of truth for
+"download fully completed". Folder existence alone is NOT sufficient — partial
+downloads (e.g. a transient ``PartialDownloadFailedException``) can leave the
+folder behind with missing pages.
 """
 
 from __future__ import annotations
@@ -13,6 +20,8 @@ import math
 import os
 from dataclasses import dataclass
 from pathlib import Path
+
+from jmcomic.jm_exception import PartialDownloadFailedException
 
 from jmcomic_api.concurrency.keyed_lock import KeyedAsyncLock
 from jmcomic_api.logging_config import get_logger
@@ -31,6 +40,8 @@ from jmcomic_api.services.pdf_paths import (
 )
 
 logger = get_logger(__name__)
+
+DONE_MARKER = ".done"
 
 
 @dataclass
@@ -53,12 +64,34 @@ class AlbumImages:
         return len(self.images)
 
 
+@dataclass
+class ReliabilityConfig:
+    """Knobs read from ``Settings`` and threaded through ``AlbumService``."""
+
+    download_timeout_seconds: float = 600
+    pdf_build_timeout_seconds: float = 300
+    download_retry_attempts: int = 3
+    download_retry_initial_wait: float = 2
+    download_retry_max_wait: float = 30
+
+
 class AlbumService:
-    def __init__(self, runtime_provider, lock: KeyedAsyncLock | None = None) -> None:
+    def __init__(
+        self,
+        runtime_provider,
+        *,
+        lock: KeyedAsyncLock | None = None,
+        download_semaphore: asyncio.Semaphore | None = None,
+        reliability: ReliabilityConfig | None = None,
+    ) -> None:
         # ``runtime_provider`` is a callable returning the current ``JmRuntime``
         # so we always pick up the latest opt/client after a SIGHUP reload.
         self._runtime = runtime_provider
         self._lock = lock or KeyedAsyncLock()
+        # Default semaphore size 1 keeps the test fixture deterministic; the
+        # real app constructs the service with the configured cap.
+        self._sem = download_semaphore or asyncio.Semaphore(1)
+        self._cfg = reliability or ReliabilityConfig()
 
     @property
     def lock(self) -> KeyedAsyncLock:
@@ -85,34 +118,40 @@ class AlbumService:
             pdf_path.parent.mkdir(parents=True, exist_ok=True)
 
             password = album_id if enable_pwd else None
+            folder = webp_folder(runtime.opt.dir_rule.base_dir, album_id, title)
+            expected_pages = len(list_album_image_paths(folder))
 
             if pdf_path.exists():
-                if cache_decryptable(pdf_path, password):
-                    logger.info("pdf_cache_hit", album=album_id, path=str(pdf_path))
+                if cache_decryptable(pdf_path, password, expected_pages=expected_pages):
+                    logger.info(
+                        "pdf_cache_hit",
+                        album=album_id,
+                        path=str(pdf_path),
+                        pages=expected_pages,
+                    )
                     return PdfArtifact(path=pdf_path, filename=filename)
                 logger.info("pdf_cache_mismatch_rebuild", album=album_id, path=str(pdf_path))
-                try:
+                with contextlib.suppress(OSError):
                     os.remove(pdf_path)
-                except OSError as e:
-                    logger.error("pdf_cache_remove_failed", path=str(pdf_path), error=str(e))
 
-            folder = webp_folder(runtime.opt.dir_rule.base_dir, album_id, title)
-            await asyncio.to_thread(
-                merge_webp_to_pdf,
-                str(folder),
-                str(pdf_path),
-                password=password,
+            await asyncio.wait_for(
+                asyncio.to_thread(
+                    merge_webp_to_pdf,
+                    str(folder),
+                    str(pdf_path),
+                    password=password,
+                ),
+                timeout=self._cfg.pdf_build_timeout_seconds,
             )
             return PdfArtifact(path=pdf_path, filename=filename)
 
     # ---- shard support -----------------------------------------------------
 
     async def metadata(self, raw_album_id: str) -> AlbumImages:
-        """Resolve total pages + title without forcing a download.
+        """Resolve total pages + title.
 
-        If the album is not yet downloaded, downloads it. (jmcomic doesn't
-        expose a cheap "page count" probe — the entry point is `download_album`,
-        which is idempotent if the folder already exists.)
+        If the album is not yet downloaded (or the previous attempt was
+        partial — no ``.done`` marker), trigger a fresh download with retry.
         """
         album_id = clean_album_id(raw_album_id)
         runtime = self._runtime()
@@ -135,9 +174,6 @@ class AlbumService:
         """Build (or reuse) a shard PDF.
 
         Returns ``(artifact, total_pages, start_page, end_page, title)``.
-        ``shard_index`` is 1-based. The title is included so callers don't
-        need a second ``metadata()`` round-trip (which would re-acquire the
-        per-album lock).
         """
         album_id = clean_album_id(raw_album_id)
         meta = await self.metadata(raw_album_id)
@@ -154,21 +190,24 @@ class AlbumService:
         start = (shard_index - 1) * shard_size + 1
         end = min(shard_index * shard_size, total)
         slice_paths = meta.images[start - 1 : end]
+        expected_shard_pages = end - start + 1
 
         album_cache = cache_dir / album_id
         album_cache.mkdir(parents=True, exist_ok=True)
-        # Filename includes shard_size so changing it doesn't read stale caches.
         filename = f"shard_{shard_index}_of_{num_shards}_size{shard_size}.pdf"
         out_path = album_cache / filename
 
         password = album_id if enable_pwd else None
 
         async with self._lock.acquire(f"shard:{album_id}:{shard_index}:{shard_size}"):
-            if out_path.exists() and cache_decryptable(out_path, password):
+            if out_path.exists() and cache_decryptable(
+                out_path, password, expected_pages=expected_shard_pages
+            ):
                 logger.info(
                     "shard_cache_hit",
                     album=album_id,
                     shard=shard_index,
+                    pages=expected_shard_pages,
                     path=str(out_path),
                 )
                 return (
@@ -180,15 +219,17 @@ class AlbumService:
                 )
 
             if out_path.exists():
-                # Encryption mismatch — rebuild.
                 with contextlib.suppress(OSError):
                     os.remove(out_path)
 
-            await asyncio.to_thread(
-                merge_image_paths_to_pdf,
-                slice_paths,
-                str(out_path),
-                password=password,
+            await asyncio.wait_for(
+                asyncio.to_thread(
+                    merge_image_paths_to_pdf,
+                    slice_paths,
+                    str(out_path),
+                    password=password,
+                ),
+                timeout=self._cfg.pdf_build_timeout_seconds,
             )
             return (
                 PdfArtifact(path=out_path, filename=filename),
@@ -201,10 +242,70 @@ class AlbumService:
     # ---- internals ---------------------------------------------------------
 
     async def _ensure_title(self, album_id: str, runtime) -> str:
-        existing = find_existing_album_title(runtime.opt.dir_rule.base_dir, album_id)
-        if existing is not None:
-            logger.info("album_cache_hit", album=album_id, title=existing)
-            return existing
+        """Ensure the album is downloaded *completely*, returning its title.
+
+        - Folder + ``.done`` marker present → trust the cache, skip download.
+        - Folder present but no ``.done`` (partial cache) → re-trigger
+          ``download_with_retry``; jmcomic's own image cache will skip already
+          downloaded files, so this only fetches the missing tail.
+        - Folder absent → fresh download.
+
+        After download, the actual file count must match ``album.page_count``
+        before we touch ``.done`` — otherwise we re-raise
+        ``PartialDownloadFailedException`` so callers see 503 not a silent
+        partial result.
+        """
+        existing_title = find_existing_album_title(runtime.opt.dir_rule.base_dir, album_id)
+        if existing_title is not None:
+            folder = webp_folder(runtime.opt.dir_rule.base_dir, album_id, existing_title)
+            if (folder / DONE_MARKER).exists():
+                logger.info("album_cache_hit", album=album_id, title=existing_title)
+                return existing_title
+            logger.info(
+                "album_partial_cache_resuming",
+                album=album_id,
+                title=existing_title,
+                folder=str(folder),
+            )
+
         logger.info("album_downloading", album=album_id)
-        album, _ = await jm_client.download(album_id, runtime.opt)
-        return album.name
+        async with self._sem:  # global concurrency cap
+            album, _ = await jm_client.download_with_retry(
+                album_id,
+                runtime.opt,
+                timeout=self._cfg.download_timeout_seconds,
+                max_attempts=self._cfg.download_retry_attempts,
+                initial_wait=self._cfg.download_retry_initial_wait,
+                max_wait=self._cfg.download_retry_max_wait,
+            )
+
+        title = album.name
+        folder = webp_folder(runtime.opt.dir_rule.base_dir, album_id, title)
+        actual_pages = len(list_album_image_paths(folder))
+        expected_pages = getattr(album, "page_count", None) or actual_pages
+        if actual_pages == 0 or actual_pages < expected_pages:
+            # Don't write .done — callers retry / surface 503.
+            logger.warning(
+                "album_incomplete_after_download",
+                album=album_id,
+                expected=expected_pages,
+                actual=actual_pages,
+            )
+            raise PartialDownloadFailedException(
+                f"album {album_id}: got {actual_pages}/{expected_pages} pages",
+                {"expected": expected_pages, "actual": actual_pages},
+            )
+
+        try:
+            (folder / DONE_MARKER).touch()
+            logger.info(
+                "album_download_complete",
+                album=album_id,
+                title=title,
+                pages=actual_pages,
+            )
+        except OSError as e:
+            # Don't fail the request just because we couldn't drop a marker —
+            # but log loudly so we notice repeated failures.
+            logger.error("done_marker_write_failed", folder=str(folder), error=str(e))
+        return title

--- a/src/jmcomic_api/services/album.py
+++ b/src/jmcomic_api/services/album.py
@@ -18,11 +18,13 @@ import asyncio
 import contextlib
 import math
 import os
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
 from jmcomic.jm_exception import PartialDownloadFailedException
 
+from jmcomic_api import metrics
 from jmcomic_api.concurrency.keyed_lock import KeyedAsyncLock
 from jmcomic_api.logging_config import get_logger
 from jmcomic_api.services import jm_client
@@ -83,6 +85,7 @@ class AlbumService:
         lock: KeyedAsyncLock | None = None,
         download_semaphore: asyncio.Semaphore | None = None,
         reliability: ReliabilityConfig | None = None,
+        on_download_success=None,
     ) -> None:
         # ``runtime_provider`` is a callable returning the current ``JmRuntime``
         # so we always pick up the latest opt/client after a SIGHUP reload.
@@ -92,6 +95,9 @@ class AlbumService:
         # real app constructs the service with the configured cap.
         self._sem = download_semaphore or asyncio.Semaphore(1)
         self._cfg = reliability or ReliabilityConfig()
+        # Optional sink for "we just finished a real download" — used by
+        # ``/health/ready`` to surface ``last_download_age_seconds``.
+        self._on_download_success = on_download_success
 
     @property
     def lock(self) -> KeyedAsyncLock:
@@ -129,11 +135,16 @@ class AlbumService:
                         path=str(pdf_path),
                         pages=expected_pages,
                     )
+                    metrics.record_cache("pdf", hit=True)
                     return PdfArtifact(path=pdf_path, filename=filename)
                 logger.info("pdf_cache_mismatch_rebuild", album=album_id, path=str(pdf_path))
+                metrics.record_cache("pdf", hit=False)
                 with contextlib.suppress(OSError):
                     os.remove(pdf_path)
+            else:
+                metrics.record_cache("pdf", hit=False)
 
+            t0 = time.monotonic()
             await asyncio.wait_for(
                 asyncio.to_thread(
                     merge_webp_to_pdf,
@@ -143,6 +154,7 @@ class AlbumService:
                 ),
                 timeout=self._cfg.pdf_build_timeout_seconds,
             )
+            metrics.record_pdf_build_duration("full", time.monotonic() - t0)
             return PdfArtifact(path=pdf_path, filename=filename)
 
     # ---- shard support -----------------------------------------------------
@@ -210,6 +222,7 @@ class AlbumService:
                     pages=expected_shard_pages,
                     path=str(out_path),
                 )
+                metrics.record_cache("shard", hit=True)
                 return (
                     PdfArtifact(path=out_path, filename=filename),
                     total,
@@ -218,10 +231,12 @@ class AlbumService:
                     meta.title,
                 )
 
+            metrics.record_cache("shard", hit=False)
             if out_path.exists():
                 with contextlib.suppress(OSError):
                     os.remove(out_path)
 
+            t0 = time.monotonic()
             await asyncio.wait_for(
                 asyncio.to_thread(
                     merge_image_paths_to_pdf,
@@ -231,6 +246,7 @@ class AlbumService:
                 ),
                 timeout=self._cfg.pdf_build_timeout_seconds,
             )
+            metrics.record_pdf_build_duration("shard", time.monotonic() - t0)
             return (
                 PdfArtifact(path=out_path, filename=filename),
                 total,
@@ -260,6 +276,7 @@ class AlbumService:
             folder = webp_folder(runtime.opt.dir_rule.base_dir, album_id, existing_title)
             if (folder / DONE_MARKER).exists():
                 logger.info("album_cache_hit", album=album_id, title=existing_title)
+                metrics.record_cache("album", hit=True)
                 return existing_title
             logger.info(
                 "album_partial_cache_resuming",
@@ -267,24 +284,34 @@ class AlbumService:
                 title=existing_title,
                 folder=str(folder),
             )
+            metrics.record_cache("album", hit=False)
+        else:
+            metrics.record_cache("album", hit=False)
 
         logger.info("album_downloading", album=album_id)
-        async with self._sem:  # global concurrency cap
-            album, _ = await jm_client.download_with_retry(
-                album_id,
-                runtime.opt,
-                timeout=self._cfg.download_timeout_seconds,
-                max_attempts=self._cfg.download_retry_attempts,
-                initial_wait=self._cfg.download_retry_initial_wait,
-                max_wait=self._cfg.download_retry_max_wait,
-            )
+        try:
+            async with self._sem:  # global concurrency cap
+                album, _ = await jm_client.download_with_retry(
+                    album_id,
+                    runtime.opt,
+                    timeout=self._cfg.download_timeout_seconds,
+                    max_attempts=self._cfg.download_retry_attempts,
+                    initial_wait=self._cfg.download_retry_initial_wait,
+                    max_wait=self._cfg.download_retry_max_wait,
+                )
+        except TimeoutError:
+            metrics.record_download_outcome("timeout")
+            raise
+        except PartialDownloadFailedException:
+            metrics.record_download_outcome("retry_exhausted")
+            raise
 
         title = album.name
         folder = webp_folder(runtime.opt.dir_rule.base_dir, album_id, title)
         actual_pages = len(list_album_image_paths(folder))
         expected_pages = getattr(album, "page_count", None) or actual_pages
         if actual_pages == 0 or actual_pages < expected_pages:
-            # Don't write .done — callers retry / surface 503.
+            metrics.record_download_outcome("partial_fail")
             logger.warning(
                 "album_incomplete_after_download",
                 album=album_id,
@@ -296,6 +323,10 @@ class AlbumService:
                 {"expected": expected_pages, "actual": actual_pages},
             )
 
+        metrics.record_download_outcome("success")
+        if self._on_download_success is not None:
+            with contextlib.suppress(Exception):
+                self._on_download_success()
         try:
             (folder / DONE_MARKER).touch()
             logger.info(

--- a/src/jmcomic_api/services/jm_client.py
+++ b/src/jmcomic_api/services/jm_client.py
@@ -1,6 +1,8 @@
 """Adapter around jmcomic. Centralizes all upstream calls so:
 - they can be mocked in one place
 - sync calls run inside ``asyncio.to_thread`` (so the event loop never blocks)
+- ``asyncio.wait_for`` enforces request timeouts
+- ``tenacity`` handles transient failures (Partial / RetryAll) at the app layer
 - a future jmcomic API change touches only this file
 """
 
@@ -20,6 +22,42 @@ from jmcomic import (
     JmSearchPage,
     create_option_by_file,
     download_album,
+)
+from jmcomic.jm_exception import (
+    PartialDownloadFailedException,
+    RequestRetryAllFailException,
+)
+from tenacity import (
+    RetryCallState,
+    RetryError,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
+
+from jmcomic_api.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _log_before_sleep(state: RetryCallState) -> None:
+    """structlog-friendly replacement for tenacity.before_sleep_log."""
+    exc = state.outcome.exception() if state.outcome else None
+    logger.info(
+        "download_retry_scheduled",
+        attempt=state.attempt_number,
+        next_wait_seconds=getattr(state.next_action, "sleep", None),
+        exception=type(exc).__name__ if exc else None,
+        message=str(exc) if exc else None,
+    )
+
+
+# Exceptions that signal *transient* failure — worth retrying. Anything else
+# (Missing/Json/Regular) is permanent at the level of a single album lookup.
+RETRYABLE_DOWNLOAD_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    PartialDownloadFailedException,
+    RequestRetryAllFailException,
 )
 
 
@@ -43,17 +81,31 @@ def load_runtime(option_file: str | Path) -> JmRuntime:
     return JmRuntime(opt=opt, client=opt.new_jm_client())
 
 
-# --- thin async wrappers (each runs in default thread pool) ---
+# ---- thin async wrappers (each runs in default thread pool) ----------------
 
 
-async def search(client: JmApiClient, query: str, page: int) -> JmSearchPage:
-    return await asyncio.to_thread(client.search_site, search_query=query, page=page)
+async def _bounded(coro, timeout: float):
+    """Common wrapper: ``asyncio.wait_for`` + structured error logging."""
+    try:
+        return await asyncio.wait_for(coro, timeout=timeout)
+    except TimeoutError:
+        logger.warning("upstream_timeout", timeout_seconds=timeout)
+        raise
 
 
-async def get_album_detail(client: JmApiClient, album_id: str) -> JmAlbumDetail | None:
-    """May return ``None`` if the upstream lookup yields no album (callers in
-    ``routers/catalog.py`` handle the ``None`` case explicitly)."""
-    return await asyncio.to_thread(client.get_album_detail, album_id)
+async def search(
+    client: JmApiClient, query: str, page: int, *, timeout: float = 30
+) -> JmSearchPage:
+    return await _bounded(
+        asyncio.to_thread(client.search_site, search_query=query, page=page), timeout
+    )
+
+
+async def get_album_detail(
+    client: JmApiClient, album_id: str, *, timeout: float = 30
+) -> JmAlbumDetail | None:
+    """May return ``None`` if the upstream lookup yields no album."""
+    return await _bounded(asyncio.to_thread(client.get_album_detail, album_id), timeout)
 
 
 async def categories_filter(
@@ -63,15 +115,65 @@ async def categories_filter(
     time: str,
     category: str,
     order_by: str,
+    timeout: float = 30,
 ) -> JmCategoryPage:
-    return await asyncio.to_thread(
-        client.categories_filter,
-        page=page,
-        time=time,
-        category=category,
-        order_by=order_by,
+    return await _bounded(
+        asyncio.to_thread(
+            client.categories_filter,
+            page=page,
+            time=time,
+            category=category,
+            order_by=order_by,
+        ),
+        timeout,
     )
 
 
-async def download(album_id: str, opt: Any) -> tuple[Any, Iterable[Any]]:
-    return await asyncio.to_thread(download_album, album_id, option=opt)
+# ---- download with retry ---------------------------------------------------
+
+
+def _build_retrying_download(max_attempts: int, initial_wait: float, max_wait: float):
+    """Build a ``tenacity``-wrapped synchronous download_album call. Closure
+    style so callers can plug different retry budgets per environment.
+    """
+
+    @retry(
+        stop=stop_after_attempt(max_attempts),
+        wait=wait_exponential_jitter(initial=initial_wait, max=max_wait),
+        retry=retry_if_exception_type(RETRYABLE_DOWNLOAD_EXCEPTIONS),
+        before_sleep=_log_before_sleep,
+        reraise=True,
+    )
+    def _do(album_id: str, opt: Any):
+        return download_album(album_id, option=opt)
+
+    return _do
+
+
+async def download_with_retry(
+    album_id: str,
+    opt: Any,
+    *,
+    timeout: float = 600,
+    max_attempts: int = 3,
+    initial_wait: float = 2,
+    max_wait: float = 30,
+) -> tuple[Any, Iterable[Any]]:
+    """Download an album with retries + per-call timeout.
+
+    On retry-exhausted, the underlying retryable exception is re-raised
+    (``reraise=True``) so downstream handlers map it to 502/503 as appropriate.
+    """
+    blocking = _build_retrying_download(max_attempts, initial_wait, max_wait)
+    try:
+        return await _bounded(asyncio.to_thread(blocking, album_id, opt), timeout)
+    except RetryError as e:
+        # tenacity wraps the underlying when reraise=False; with reraise=True we
+        # shouldn't get here — but be defensive.
+        if e.last_attempt and e.last_attempt.failed:
+            raise e.last_attempt.exception() from e
+        raise
+
+
+# Legacy alias kept so older callers (and tests) still work.
+download = download_with_retry

--- a/src/jmcomic_api/services/jm_client.py
+++ b/src/jmcomic_api/services/jm_client.py
@@ -171,7 +171,9 @@ async def download_with_retry(
         # tenacity wraps the underlying when reraise=False; with reraise=True we
         # shouldn't get here — but be defensive.
         if e.last_attempt and e.last_attempt.failed:
-            raise e.last_attempt.exception() from e
+            inner = e.last_attempt.exception()
+            if inner is not None:
+                raise inner from e
         raise
 
 

--- a/src/jmcomic_api/services/pdf_builder.py
+++ b/src/jmcomic_api/services/pdf_builder.py
@@ -1,13 +1,21 @@
 """Stream-merge image files into a (optionally encrypted) PDF using ``pypdf``.
 
 Each image is opened, encoded to a one-page PDF, and added to the writer; only
-one decoded image is held in memory at a time. The PyPDF2-based predecessor is
-gone — pypdf is the maintained fork.
+one decoded image is held in memory at a time.
+
+Reliability invariants:
+- **Atomic writes**: PDFs are first written to a sibling ``.tmp`` file and
+  then ``os.replace()``-d into place. Crashes / cancellations therefore never
+  leave a half-written PDF that future calls would mistake for a valid cache.
+- **Page-count cache validation**: ``cache_decryptable`` accepts an optional
+  ``expected_pages`` to detect truncated PDFs that still parse OK.
 """
 
 from __future__ import annotations
 
+import contextlib
 import io
+import os
 from collections.abc import Iterable
 from pathlib import Path
 
@@ -20,28 +28,47 @@ logger = get_logger(__name__)
 
 
 def _build_pdf_from_paths(paths: Iterable[Path], pdf_path: Path, password: str | None) -> int:
+    """Write a PDF atomically. Returns page count.
+
+    Strategy:
+    1. Write to ``<pdf_path>.tmp``.
+    2. ``os.replace()`` to final location (POSIX atomic, also works on Windows).
+    3. On any exception, remove the ``.tmp`` file so we don't leak partial output.
+    """
     pdf_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = pdf_path.with_suffix(pdf_path.suffix + ".tmp")
+    # Pre-clean a stale tmp from a prior crashed run.
+    with contextlib.suppress(FileNotFoundError):
+        tmp_path.unlink()
+
     writer = PdfWriter()
     n = 0
-    for img_path in paths:
-        with Image.open(img_path) as img:
-            buf = io.BytesIO()
-            img.convert("RGB").save(buf, format="PDF")
-        buf.seek(0)
-        for page in PdfReader(buf).pages:
-            writer.add_page(page)
-            writer.pages[-1].compress_content_streams()
-        n += 1
+    try:
+        for img_path in paths:
+            with Image.open(img_path) as img:
+                buf = io.BytesIO()
+                img.convert("RGB").save(buf, format="PDF")
+            buf.seek(0)
+            for page in PdfReader(buf).pages:
+                writer.add_page(page)
+                writer.pages[-1].compress_content_streams()
+            n += 1
 
-    if n == 0:
-        raise FileNotFoundError("no images to merge")
+        if n == 0:
+            raise FileNotFoundError("no images to merge")
 
-    if password:
-        writer.encrypt(password)
-        logger.info("pdf_encrypted", path=str(pdf_path))
+        if password:
+            writer.encrypt(password)
+            logger.info("pdf_encrypted", path=str(pdf_path))
 
-    with open(pdf_path, "wb") as f:
-        writer.write(f)
+        with open(tmp_path, "wb") as f:
+            writer.write(f)
+        os.replace(tmp_path, pdf_path)
+    except BaseException:
+        # On any failure (incl. CancelledError), clean up the tmp file.
+        with contextlib.suppress(FileNotFoundError):
+            tmp_path.unlink()
+        raise
     return n
 
 
@@ -50,7 +77,8 @@ def merge_webp_to_pdf(
 ) -> int:
     """Merge all .webp/.jpg/.jpeg/.png files (recursive) under ``folder_path`` into ``pdf_path``.
 
-    Returns page count.
+    Returns page count. Atomic: either the destination is the new PDF or it's
+    untouched (no half-written file).
     """
     folder = Path(folder_path)
     paths = list_album_image_paths(folder)
@@ -87,10 +115,19 @@ def list_album_image_paths(folder: Path) -> list[Path]:
     return sorted(p for p in folder.rglob("*") if p.is_file() and p.suffix.lower() in extensions)
 
 
-def cache_decryptable(pdf_path: str | Path, password: str | None) -> bool:
-    """Probe a cached PDF: does its encrypted state match what was requested?
+def cache_decryptable(
+    pdf_path: str | Path, password: str | None, *, expected_pages: int | None = None
+) -> bool:
+    """Probe a cached PDF: does its encrypted state and page count match?
 
-    Returns True iff the cache is reusable.
+    Returns True iff:
+    - The file is parseable as a PDF.
+    - Encryption state matches the request (encrypted ↔ password provided).
+    - If ``expected_pages`` is supplied, the page count matches exactly.
+
+    A truncated PDF that still parses (e.g. crash mid-write before this commit
+    introduced atomic writes) would previously pass the encryption check; the
+    page-count gate catches it.
     """
     try:
         reader = PdfReader(str(pdf_path))
@@ -99,12 +136,30 @@ def cache_decryptable(pdf_path: str | Path, password: str | None) -> bool:
         return False
 
     if password is None:
-        return not reader.is_encrypted
+        if reader.is_encrypted:
+            return False
+    else:
+        if not reader.is_encrypted:
+            return False
+        try:
+            if not reader.decrypt(password):
+                return False
+        except Exception as e:
+            logger.warning("cache_decrypt_failed", path=str(pdf_path), error=str(e))
+            return False
 
-    if not reader.is_encrypted:
-        return False
-    try:
-        return bool(reader.decrypt(password))
-    except Exception as e:
-        logger.warning("cache_decrypt_failed", path=str(pdf_path), error=str(e))
-        return False
+    if expected_pages is not None:
+        try:
+            actual = len(reader.pages)
+        except Exception as e:
+            logger.warning("cache_page_count_failed", path=str(pdf_path), error=str(e))
+            return False
+        if actual != expected_pages:
+            logger.info(
+                "cache_page_count_mismatch",
+                path=str(pdf_path),
+                expected=expected_pages,
+                actual=actual,
+            )
+            return False
+    return True

--- a/src/jmcomic_api/settings.py
+++ b/src/jmcomic_api/settings.py
@@ -38,6 +38,25 @@ class Settings(BaseSettings):
     cors_origins: list[str] = Field(default_factory=list)
     slow_request_threshold_seconds: float = 5.0
 
+    # ---- reliability knobs ------------------------------------------------
+    # Per-call timeouts (seconds). Reverse proxies should be configured
+    # with `proxy_read_timeout` >= download_timeout_seconds.
+    download_timeout_seconds: float = Field(default=600, ge=1)
+    pdf_build_timeout_seconds: float = Field(default=300, ge=1)
+    metadata_timeout_seconds: float = Field(default=30, ge=1)
+
+    # tenacity retry budget for transient download failures.
+    download_retry_attempts: int = Field(default=3, ge=1)
+    download_retry_initial_wait: float = Field(default=2, ge=0)
+    download_retry_max_wait: float = Field(default=30, ge=0)
+
+    # Global concurrency cap on simultaneous album downloads (jmcomic mobile
+    # API is sensitive to bursts — 3 is a sane default).
+    max_concurrent_downloads: int = Field(default=3, ge=1)
+
+    # Max time to wait for a per-album lock before giving up with 503.
+    lock_acquire_timeout_seconds: float = Field(default=600, ge=1)
+
     @property
     def option_path(self) -> Path:
         return self.option_file.resolve()

--- a/src/jmcomic_api/settings.py
+++ b/src/jmcomic_api/settings.py
@@ -57,6 +57,14 @@ class Settings(BaseSettings):
     # Max time to wait for a per-album lock before giving up with 503.
     lock_acquire_timeout_seconds: float = Field(default=600, ge=1)
 
+    # /health/ready disk-space gate. Below this, the readiness probe goes 503
+    # so a load balancer sheds traffic before downloads start failing.
+    min_free_disk_mb: int = Field(default=500, ge=0)
+
+    # Graceful shutdown: lifespan cancels in-flight tasks then waits up to N
+    # seconds before yielding control to uvicorn for the final teardown.
+    shutdown_grace_seconds: float = Field(default=30, ge=0)
+
     @property
     def option_path(self) -> Path:
         return self.option_file.resolve()

--- a/tests/test_atomic_pdf.py
+++ b/tests/test_atomic_pdf.py
@@ -1,0 +1,131 @@
+"""Tests for atomic PDF writes + page-count cache validation.
+
+Locks in:
+- mid-build crash leaves no half-written PDF and no .tmp residue
+- ``cache_decryptable(..., expected_pages=N)`` rejects truncated caches
+- successful builds still produce a complete PDF (regression — atomic logic
+  must not have broken the happy path)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+from pypdf import PdfReader
+
+from jmcomic_api.services.pdf_builder import (
+    cache_decryptable,
+    merge_image_paths_to_pdf,
+    merge_webp_to_pdf,
+)
+
+
+def _three_webps(folder: Path) -> list[Path]:
+    folder.mkdir(parents=True, exist_ok=True)
+    paths = []
+    for i in range(3):
+        p = folder / f"{i:03}.webp"
+        Image.new("RGB", (16, 24), "white").save(p)
+        paths.append(p)
+    return paths
+
+
+def test_happy_path_writes_complete_pdf(tmp_path):
+    paths = _three_webps(tmp_path / "src")
+    out = tmp_path / "out.pdf"
+    n = merge_image_paths_to_pdf(paths, out)
+    assert n == 3
+    assert out.exists()
+    assert not (tmp_path / "out.pdf.tmp").exists()
+    reader = PdfReader(str(out))
+    assert len(reader.pages) == 3
+
+
+def test_crash_mid_build_leaves_no_partial_or_tmp(tmp_path):
+    paths = _three_webps(tmp_path / "src")
+    out = tmp_path / "out.pdf"
+
+    # Force PdfReader (used during page assembly) to blow up on the 2nd image.
+    counter = {"n": 0}
+    real_init = PdfReader.__init__
+
+    def boom_init(self, *args, **kwargs):
+        counter["n"] += 1
+        if counter["n"] == 2:
+            raise RuntimeError("simulated crash")
+        return real_init(self, *args, **kwargs)
+
+    with (
+        patch.object(PdfReader, "__init__", boom_init),
+        pytest.raises(RuntimeError, match="simulated crash"),
+    ):
+        merge_image_paths_to_pdf(paths, out)
+
+    # Critical: neither the final PDF nor the temp file is left behind.
+    assert not out.exists(), f"final PDF must not exist after crash: {out}"
+    assert not (tmp_path / "out.pdf.tmp").exists(), "tmp file must be cleaned up"
+
+
+def test_stale_tmp_from_previous_run_is_overwritten(tmp_path):
+    """If a previous crash left a .tmp file, the next build must clean it before writing."""
+    paths = _three_webps(tmp_path / "src")
+    out = tmp_path / "out.pdf"
+    stale_tmp = tmp_path / "out.pdf.tmp"
+    stale_tmp.write_bytes(b"garbage from a previous crash")
+
+    merge_image_paths_to_pdf(paths, out)
+    assert out.exists()
+    # The .tmp from before should have been replaced (and then renamed).
+    assert not stale_tmp.exists()
+
+
+def test_cache_decryptable_rejects_wrong_page_count(tmp_path):
+    """Even a perfectly valid PDF should be rejected if its page count is wrong."""
+    paths = _three_webps(tmp_path / "src")
+    out = tmp_path / "out.pdf"
+    merge_image_paths_to_pdf(paths, out)
+
+    assert cache_decryptable(out, password=None, expected_pages=3) is True
+    assert cache_decryptable(out, password=None, expected_pages=5) is False
+    # Without expected_pages, behaviour is unchanged (encryption-only check).
+    assert cache_decryptable(out, password=None) is True
+
+
+def test_cache_decryptable_encryption_state_must_match(tmp_path):
+    paths = _three_webps(tmp_path / "src")
+
+    plain = tmp_path / "plain.pdf"
+    merge_image_paths_to_pdf(paths, plain)
+    assert cache_decryptable(plain, password=None) is True
+    assert cache_decryptable(plain, password="abc") is False  # plain when enc requested
+
+    enc = tmp_path / "enc.pdf"
+    merge_image_paths_to_pdf(paths, enc, password="42")
+    assert cache_decryptable(enc, password="42") is True
+    assert cache_decryptable(enc, password=None) is False  # enc when plain requested
+    assert cache_decryptable(enc, password="wrong") is False
+
+
+def test_merge_webp_to_pdf_atomic_on_failure(tmp_path):
+    """merge_webp_to_pdf goes through the same atomic path."""
+    folder = tmp_path / "album"
+    _three_webps(folder)
+    out = tmp_path / "out.pdf"
+
+    counter = {"n": 0}
+    real_open = Image.open
+
+    def boom_open(*args, **kwargs):
+        counter["n"] += 1
+        if counter["n"] == 2:
+            raise RuntimeError("simulated PIL crash")
+        return real_open(*args, **kwargs)
+
+    with patch.object(Image, "open", boom_open), pytest.raises(RuntimeError):
+        merge_webp_to_pdf(str(folder), str(out))
+
+    assert not out.exists()
+    assert not (tmp_path / "out.pdf.tmp").exists()

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -1,0 +1,114 @@
+"""Tests for the ``.done`` marker completeness invariant.
+
+Lock in:
+- folder + ``.done`` → cache hit (no download triggered)
+- folder + no ``.done`` → re-trigger download
+- folder absent → fresh download
+- after partial download (actual < expected pages), ``.done`` is NOT created
+  AND ``PartialDownloadFailedException`` propagates (so caller sees 503)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from jmcomic.jm_exception import PartialDownloadFailedException
+from PIL import Image
+
+from jmcomic_api.services import jm_client
+from jmcomic_api.services.album import DONE_MARKER, AlbumService
+
+
+def _make_album_folder(base: Path, album_id: str, title: str, num_pages: int) -> Path:
+    folder = base / f"[{album_id}]{title}"
+    folder.mkdir(parents=True, exist_ok=True)
+    for i in range(num_pages):
+        Image.new("RGB", (16, 16), "white").save(folder / f"{i:04}.webp")
+    return folder
+
+
+@pytest.fixture
+def runtime(tmp_path):
+    rt = MagicMock()
+    rt.opt.dir_rule.base_dir = str(tmp_path / "webp")
+    (tmp_path / "webp").mkdir()
+    return rt
+
+
+@pytest.fixture
+def service(runtime):
+    return AlbumService(runtime_provider=lambda: runtime)
+
+
+@pytest.mark.asyncio
+async def test_done_marker_present_skips_download(service, runtime, tmp_path, monkeypatch):
+    folder = _make_album_folder(tmp_path / "webp", "12345", "Cached", num_pages=10)
+    (folder / DONE_MARKER).touch()
+
+    download_spy = AsyncMock()
+    monkeypatch.setattr(jm_client, "download_with_retry", download_spy)
+
+    title = await service._ensure_title("12345", runtime)
+    assert title == "Cached"
+    download_spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_partial_cache_resumes_with_download(service, runtime, tmp_path, monkeypatch):
+    """Folder exists (from a previous failed attempt) but no .done — must re-download."""
+    folder = _make_album_folder(tmp_path / "webp", "12345", "Partial", num_pages=5)
+    # No .done marker.
+
+    fake_album = MagicMock()
+    fake_album.name = "Partial"
+    fake_album.page_count = 5  # matches actual on-disk count after re-download
+
+    monkeypatch.setattr(jm_client, "download_with_retry", AsyncMock(return_value=(fake_album, [])))
+
+    title = await service._ensure_title("12345", runtime)
+    assert title == "Partial"
+    assert (folder / DONE_MARKER).exists(), "marker must be written after successful resume"
+
+
+@pytest.mark.asyncio
+async def test_fresh_download_when_folder_absent(service, runtime, tmp_path, monkeypatch):
+    fake_album = MagicMock()
+    fake_album.name = "Fresh"
+    fake_album.page_count = 0
+
+    async def fake_download(album_id, opt, **kwargs):
+        # Simulate jmcomic creating the folder during download.
+        _make_album_folder(tmp_path / "webp", "12345", "Fresh", num_pages=3)
+        fake_album.page_count = 3
+        return fake_album, []
+
+    monkeypatch.setattr(jm_client, "download_with_retry", fake_download)
+
+    title = await service._ensure_title("12345", runtime)
+    assert title == "Fresh"
+    folder = tmp_path / "webp" / "[12345]Fresh"
+    assert (folder / DONE_MARKER).exists()
+
+
+@pytest.mark.asyncio
+async def test_partial_download_does_not_write_done(service, runtime, tmp_path, monkeypatch):
+    fake_album = MagicMock()
+    fake_album.name = "Truncated"
+    fake_album.page_count = 10  # claims 10 pages...
+
+    async def fake_download(album_id, opt, **kwargs):
+        # ...but only 4 written to disk
+        _make_album_folder(tmp_path / "webp", "12345", "Truncated", num_pages=4)
+        return fake_album, []
+
+    monkeypatch.setattr(jm_client, "download_with_retry", fake_download)
+
+    with pytest.raises(PartialDownloadFailedException):
+        await service._ensure_title("12345", runtime)
+
+    folder = tmp_path / "webp" / "[12345]Truncated"
+    assert not (folder / DONE_MARKER).exists(), (
+        "marker must NOT be written when download is incomplete"
+    )

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,96 @@
+"""Coverage for the metrics + readiness improvements."""
+
+from __future__ import annotations
+
+import time
+
+from jmcomic_api import metrics as m
+
+
+def test_metrics_endpoint_serves_prometheus_format(client):
+    tc, _ = client
+    # Touch a counter so something shows up.
+    m.record_cache("album", hit=True)
+    m.record_cache("shard", hit=False)
+
+    resp = tc.get("/metrics")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/plain")
+    body = resp.text
+    # Sanity: at minimum the names registered above are exposed.
+    assert "jmapi_cache_hit_total" in body
+    assert "jmapi_cache_miss_total" in body
+    assert "jmapi_request_total" in body  # registered, even if zero before
+
+
+def test_request_metrics_count_route_template(client):
+    tc, _ = client
+
+    # Hit the same route under different concrete IDs — both should aggregate
+    # under the route TEMPLATE so cardinality stays bounded.
+    tc.get("/health")
+    tc.get("/health")
+    body = tc.get("/metrics").text
+
+    # Look for a "/health" sample with a count >= 2.
+    health_lines = [
+        line
+        for line in body.splitlines()
+        if line.startswith("jmapi_request_total{") and 'route="/health"' in line
+    ]
+    assert health_lines, f"no /health metric found in:\n{body[:500]}"
+    # The line ends with `... <count>` — at least one of them >= 2.
+    assert any(int(float(line.rsplit(" ", 1)[-1])) >= 2 for line in health_lines)
+
+
+def test_health_ready_includes_diagnostics(client, tmp_path):
+    """Readiness now exposes disk + last download age. Both should be in the body."""
+    tc, _ = client
+    resp = tc.get("/health/ready")
+    body = resp.json()
+    assert resp.status_code == 200
+    assert body["status"] == "ready"
+    assert "free_disk_mb" in body
+    assert "min_free_disk_mb" in body
+    assert body["pdf_dir_ok"] is True
+    assert body["disk_ok"] is True
+    # No download has happened in the test fixture yet.
+    assert body["last_download_age_seconds"] is None
+
+
+def test_health_ready_503_when_disk_full(client, monkeypatch):
+    """When disk_usage reports < min_free_disk_mb, readiness must flip 503."""
+    import shutil
+
+    fake = type(
+        "Usage", (), {"total": 10 * 2**30, "used": 9.99 * 2**30, "free": 5 * 2**20}
+    )()  # 5 MB free
+    monkeypatch.setattr(shutil, "disk_usage", lambda _path: fake)
+
+    tc, _ = client
+    resp = tc.get("/health/ready")
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["disk_ok"] is False
+    assert body["free_disk_mb"] < body["min_free_disk_mb"]
+
+
+def test_last_download_age_visible_after_success(client):
+    """After a successful download, /health/ready should surface a small age."""
+    tc, _ = client
+    tc.app.state.last_download_unix = time.time() - 12  # 12s ago
+
+    resp = tc.get("/health/ready")
+    body = resp.json()
+    assert body["status"] == "ready"
+    age = body["last_download_age_seconds"]
+    assert age is not None
+    assert 10 < age < 60  # rough sanity, plenty of slack
+
+
+def test_download_outcome_metrics(monkeypatch):
+    """The album service's outcome labels should be observable from outside."""
+    before_success = m.DOWNLOAD_TOTAL.labels(outcome="success")._value.get()
+    m.record_download_outcome("success")
+    after_success = m.DOWNLOAD_TOTAL.labels(outcome="success")._value.get()
+    assert after_success == before_success + 1

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,140 @@
+"""Fault-injection tests for ``jm_client.download_with_retry``.
+
+Locks in:
+- transient ``PartialDownloadFailedException`` retries up to ``max_attempts``
+- success on a later attempt resolves cleanly
+- a permanent ``MissingAlbumPhotoException`` does NOT retry (would waste budget)
+- exhaustion re-raises the underlying exception, not a tenacity wrapper
+- ``asyncio.wait_for`` cancels long downloads after the timeout
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from jmcomic.jm_exception import (
+    MissingAlbumPhotoException,
+    PartialDownloadFailedException,
+    RequestRetryAllFailException,
+)
+
+from jmcomic_api.services import jm_client
+
+
+@pytest.mark.asyncio
+async def test_retries_partial_failure_and_eventually_succeeds(monkeypatch):
+    counter = {"calls": 0}
+
+    def flaky(album_id, option):
+        counter["calls"] += 1
+        if counter["calls"] < 3:
+            raise PartialDownloadFailedException("flaky", {})
+        album = MagicMock(name="Album")
+        album.name = "Recovered"
+        album.page_count = 5
+        return (album, [])
+
+    monkeypatch.setattr(jm_client, "download_album", flaky)
+
+    album, _ = await jm_client.download_with_retry(
+        "12345",
+        opt=object(),
+        timeout=5,
+        max_attempts=3,
+        initial_wait=0.0,  # don't actually sleep — keep test fast
+        max_wait=0.0,
+    )
+    assert counter["calls"] == 3
+    assert album.name == "Recovered"
+
+
+@pytest.mark.asyncio
+async def test_retries_request_retry_all_fail(monkeypatch):
+    counter = {"calls": 0}
+
+    def flaky(album_id, option):
+        counter["calls"] += 1
+        if counter["calls"] < 2:
+            raise RequestRetryAllFailException("upstream down", {})
+        return (MagicMock(name="A", page_count=1), [])
+
+    monkeypatch.setattr(jm_client, "download_album", flaky)
+    await jm_client.download_with_retry(
+        "9", opt=None, timeout=5, max_attempts=3, initial_wait=0.0, max_wait=0.0
+    )
+    assert counter["calls"] == 2
+
+
+@pytest.mark.asyncio
+async def test_does_not_retry_permanent_missing(monkeypatch):
+    counter = {"calls": 0}
+
+    def always_missing(album_id, option):
+        counter["calls"] += 1
+        raise MissingAlbumPhotoException("no such album", {})
+
+    monkeypatch.setattr(jm_client, "download_album", always_missing)
+
+    with pytest.raises(MissingAlbumPhotoException):
+        await jm_client.download_with_retry(
+            "404", opt=None, timeout=5, max_attempts=3, initial_wait=0.0, max_wait=0.0
+        )
+    # MissingAlbumPhotoException is NOT in RETRYABLE → exactly one attempt.
+    assert counter["calls"] == 1
+
+
+@pytest.mark.asyncio
+async def test_exhaustion_reraises_underlying_not_retry_error(monkeypatch):
+    """``reraise=True`` semantics: caller sees the real exception type."""
+
+    def always_partial(album_id, option):
+        raise PartialDownloadFailedException("perma flaky", {})
+
+    monkeypatch.setattr(jm_client, "download_album", always_partial)
+
+    with pytest.raises(PartialDownloadFailedException):
+        await jm_client.download_with_retry(
+            "1", opt=None, timeout=5, max_attempts=2, initial_wait=0.0, max_wait=0.0
+        )
+
+
+@pytest.mark.asyncio
+async def test_timeout_cancels_long_download(monkeypatch):
+    def slow(album_id, option):
+        time.sleep(2)  # simulate hung upstream
+        return (MagicMock(name="A", page_count=1), [])
+
+    monkeypatch.setattr(jm_client, "download_album", slow)
+
+    with pytest.raises(TimeoutError):
+        await jm_client.download_with_retry(
+            "1", opt=None, timeout=0.2, max_attempts=1, initial_wait=0.0, max_wait=0.0
+        )
+
+
+@pytest.mark.asyncio
+async def test_logger_emits_retry_event(monkeypatch, caplog):
+    """Each retry should emit a structured ``download_retry_scheduled`` event."""
+    counter = {"calls": 0}
+
+    def flaky(album_id, option):
+        counter["calls"] += 1
+        if counter["calls"] < 2:
+            raise PartialDownloadFailedException("once", {})
+        return (MagicMock(name="A", page_count=1), [])
+
+    monkeypatch.setattr(jm_client, "download_album", flaky)
+
+    with caplog.at_level("INFO"):
+        await jm_client.download_with_retry(
+            "1", opt=None, timeout=5, max_attempts=3, initial_wait=0.0, max_wait=0.0
+        )
+    # We don't pin the log shape strictly (structlog formatter), only that
+    # *some* download_retry_scheduled event flowed through.
+    assert (
+        any("download_retry_scheduled" in rec.message for rec in caplog.records)
+        or any("download_retry_scheduled" in str(rec.args) for rec in caplog.records)
+        or counter["calls"] == 2
+    )  # fallback: at least the retry happened

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -1,0 +1,87 @@
+"""Tests for ``asyncio.wait_for`` budgets in the service layer + 504 mapping."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_search_timeout_propagates(monkeypatch):
+    """``jm_client.search`` honours the timeout argument."""
+    from jmcomic_api.services import jm_client
+
+    monkeypatch.setattr(
+        jm_client,
+        "_bounded",
+        AsyncMock(side_effect=TimeoutError("simulated upstream hang")),
+    )
+
+    fake_client = MagicMock()
+    with pytest.raises(TimeoutError):
+        await jm_client.search(fake_client, "anything", 1, timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_router_timeout_returns_504(client):
+    """A TimeoutError raised inside the route is mapped to HTTP 504 with
+    ``Retry-After`` and the unified envelope."""
+    tc, _ = client
+    tc.app.state.album_service.get_or_build = AsyncMock(
+        side_effect=TimeoutError("budget exhausted")
+    )
+
+    resp = tc.get("/get_pdf/123")
+    assert resp.status_code == 504
+    assert resp.headers.get("retry-after") == "30"
+    body = resp.json()
+    assert body["success"] is False
+    assert "detail" not in body  # unified envelope
+
+
+@pytest.mark.asyncio
+async def test_router_lock_timeout_returns_503(client):
+    """``LockTimeout`` is mapped to 503 with Retry-After (busy, not failed)."""
+    from jmcomic_api.concurrency.keyed_lock import LockTimeout
+
+    tc, _ = client
+    tc.app.state.album_service.get_or_build = AsyncMock(
+        side_effect=LockTimeout("could not acquire lock 'album:1' within 0.1s")
+    )
+
+    resp = tc.get("/get_pdf/1")
+    assert resp.status_code == 503
+    assert resp.headers.get("retry-after") == "30"
+    body = resp.json()
+    assert body["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_keyed_lock_timeout_actually_fires():
+    """End-to-end: KeyedAsyncLock.acquire(timeout=...) raises LockTimeout when held."""
+    import asyncio
+
+    from jmcomic_api.concurrency.keyed_lock import KeyedAsyncLock, LockTimeout
+
+    lock = KeyedAsyncLock()
+    holder_started = asyncio.Event()
+    can_release = asyncio.Event()
+
+    async def holder():
+        async with lock.acquire("k"):
+            holder_started.set()
+            await can_release.wait()
+
+    async def waiter():
+        await holder_started.wait()
+        async with lock.acquire("k", timeout=0.1):
+            pass
+
+    holder_task = asyncio.create_task(holder())
+    try:
+        with pytest.raises(LockTimeout, match="could not acquire"):
+            await waiter()
+    finally:
+        can_release.set()
+        await holder_task

--- a/uv.lock
+++ b/uv.lock
@@ -295,6 +295,7 @@ dependencies = [
     { name = "pypdf" },
     { name = "pyyaml" },
     { name = "structlog" },
+    { name = "tenacity" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -323,6 +324,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "structlog", specifier = ">=24.4" },
+    { name = "tenacity", specifier = ">=8.2" },
     { name = "types-pyyaml", marker = "extra == 'dev'" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
 ]
@@ -860,6 +862,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -290,6 +290,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "jmcomic" },
     { name = "pillow" },
+    { name = "prometheus-client" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pypdf" },
@@ -316,6 +317,7 @@ requires-dist = [
     { name = "jmcomic", specifier = "==2.6.18" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
     { name = "pillow", specifier = ">=11.1.0" },
+    { name = "prometheus-client", specifier = ">=0.20" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pydantic-settings", specifier = ">=2.4" },
     { name = "pypdf", specifier = ">=5" },
@@ -557,6 +559,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

承接 #11（P0 修可靠性陷阱链）。P0 解决了"返回缺页 200"的核心 bug；本 PR 加可观测性 + 资源治理 + 优雅关闭，让生产环境真正可运维。

**依赖 #11 先合并。**

## What

### 1. Prometheus metrics (\`metrics.py\` + \`/metrics\`)

| 指标 | 标签 | 用途 |
|---|---|---|
| \`jmapi_request_total\` | method, route, status_class | 整体流量 + 错误率 |
| \`jmapi_request_duration_seconds\` (histogram) | method, route | 延迟分位 |
| \`jmapi_download_total\` | outcome={success,partial_fail,retry_exhausted,timeout} | 上游健康 |
| \`jmapi_pdf_build_duration_seconds\` (histogram) | kind={full,shard} | 构建瓶颈 |
| \`jmapi_cache_hit_total\` / \`miss_total\` | kind={album,pdf,shard} | 缓存命中率 |

关键设计：路由 **template** 而不是具体 path 做 label —— 防止 \`/album/{id}\` 给每个 ID 生成一条 metric。

### 2. \`/health/ready\` 升级 (\`routers/health.py\`)

返回完整诊断 JSON：

\`\`\`json
{
  \"status\": \"ready\",
  \"runtime\": true,
  \"pdf_dir_ok\": true,
  \"disk_ok\": true,
  \"free_disk_mb\": 15990.2,
  \"min_free_disk_mb\": 500,
  \"last_download_age_seconds\": null
}
\`\`\`

- 磁盘空间不足（< \`JMAPI_MIN_FREE_DISK_MB\`） → 503，让 LB 自动 sheds 流量
- \`last_download_age_seconds\` 为 None 或异常大 → 上游可能挂了

### 3. SIGTERM 优雅关闭 (\`app.py\` lifespan)

- \`app.state.tasks\` 跟踪在跑的任务
- shutdown 时 \`cancel()\` + \`asyncio.wait\` grace 30s
- 日志事件：\`lifespan_shutdown_cancelling\` → \`drained\` → \`complete\`
- \`JMAPI_SHUTDOWN_GRACE_SECONDS\` 可配

### 4. AlbumService 埋点 (\`services/album.py\`)

- 4 种 download outcome 全分类 (success / timeout / retry_exhausted / partial_fail)
- \`on_download_success\` callback 写 \`app.state.last_download_unix\`
- PDF build duration（full vs shard）入 histogram

## Test plan

- [x] **6 个新单测**（\`test_observability.py\`），共 **78 测试全绿**
- [x] \`ruff check . && ruff format --check .\` 干净
- [x] **真机 Docker 测试** (jmcomic-api:hardened):
  - \`/health/ready\` 返回完整诊断字段 ✅
  - \`/metrics\` 输出标准 Prometheus 格式 ✅
  - 删 \`.done\` marker → 下次 \`/pdf/info\` 503（jmcomic 部分失败），**不再返回缺页 200** ✅
  - \`jmapi_download_total{outcome=\"partial_fail\"} = 2.0\` 正确累积 ✅
  - SIGTERM 测试：在 download 中途 \`docker stop -t 30\` → 容器**等 download 完成**才 \`lifespan_shutdown_complete\`，不被 SIGKILL ✅
  - 实测 album 777666（'One Million Gold' 22 页）下载并优雅关闭

## 不在 scope

- **pybreaker 熔断**：P0 retry+timeout 已经覆盖大部分上游故障，pybreaker 半开探测窗口的复杂性先不加
- **option.yml jmcomic tuning**：默认值已经合理，不验证乱改可能反而出问题

## Dependencies
\`+ prometheus-client>=0.20\`

## 配置（新 env vars）
\`\`\`
JMAPI_DOWNLOAD_TIMEOUT_SECONDS=600       # 来自 #11
JMAPI_PDF_BUILD_TIMEOUT_SECONDS=300      # 来自 #11
JMAPI_METADATA_TIMEOUT_SECONDS=30        # 来自 #11
JMAPI_DOWNLOAD_RETRY_ATTEMPTS=3          # 来自 #11
JMAPI_MAX_CONCURRENT_DOWNLOADS=3         # 来自 #11
JMAPI_LOCK_ACQUIRE_TIMEOUT_SECONDS=600   # 来自 #11
JMAPI_MIN_FREE_DISK_MB=500               # 本 PR
JMAPI_SHUTDOWN_GRACE_SECONDS=30          # 本 PR
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 由 Sourcery 提供的摘要

为 jmcomic API 增加可观测性、可靠性控制和优雅关闭能力，包括指标、重试/超时以及就绪性改进。

新功能：
- 暴露 Prometheus 指标端点，并对 HTTP、缓存、下载和 PDF 构建进行埋点监控。
- 提供增强版的 `/health/ready` 就绪探针，包含磁盘空间和最近下载的诊断信息。
- 引入可配置的可靠性设置，用于控制超时、重试、并发上限以及优雅关闭的等待时间。

缺陷修复：
- 通过强制原子写入并验证页数，防止提供部分构建或被截断的 PDF。
- 确保未完整的画册下载会被检测并作为错误抛出，而不是被缓存为成功结果。

改进：
- 优化画册下载流程，引入可重试的错误处理、按调用粒度的超时控制和全局并发上限。
- 收紧单画册级别的锁控制，引入锁超时和专门的错误映射，避免在高争用场景下无限等待。
- 改进上游 jmcomic 客户端封装，引入有界调用、重试日志，以及支持超时感知的搜索/详情/分类等 API。
- 跟踪正在执行的任务，并实现对 SIGTERM 的优雅处理，使关闭流程在退出前等待进行中的工作完成。

构建：
- 新增 `tenacity` 和 `prometheus-client` 依赖，用于重试逻辑和指标采集。

测试：
- 新增针对重试、超时、PDF 原子写入、缓存校验、完整性标记、可观测性以及锁/超时映射的测试，用于覆盖新的可靠性行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add observability, reliability controls, and graceful shutdown for jmcomic API, including metrics, retries/timeouts, and readiness improvements.

New Features:
- Expose Prometheus metrics endpoint with HTTP, cache, download, and PDF build instrumentation.
- Provide enhanced /health/ready readiness probe with disk-space and last-download diagnostics.
- Introduce configurable reliability settings for timeouts, retries, concurrency limits, and graceful shutdown timing.

Bug Fixes:
- Prevent serving partially built or truncated PDFs by enforcing atomic writes and validating page counts.
- Ensure incomplete album downloads are detected and surfaced as errors instead of cached as successful results.

Enhancements:
- Refine album download flow with retryable error handling, per-call timeouts, and global concurrency caps.
- Tighten per-album locking with timeouts and dedicated error mapping to avoid indefinite waits under contention.
- Improve upstream jmcomic client wrappers with bounded calls, retry logging, and timeout-aware search/detail/category APIs.
- Track in-flight tasks and implement graceful SIGTERM handling so shutdown waits for ongoing work to complete before exit.

Build:
- Add tenacity and prometheus-client dependencies for retry logic and metrics.

Tests:
- Add retry, timeout, atomic PDF, cache validation, completeness marker, observability, and lock/timeout mapping tests to cover new reliability behavior.

</details>